### PR TITLE
Add ? to WidgetsBinding.instance (null safety)

### DIFF
--- a/lib/flutter_overlay_loader.dart
+++ b/lib/flutter_overlay_loader.dart
@@ -99,7 +99,7 @@ class Loader extends StatelessWidget {
       });
 
       try {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
+        WidgetsBinding.instance?.addPostFrameCallback((_) {
           if (_currentLoader != null) {
             _overlayState?.insert(_currentLoader!);
           }


### PR DESCRIPTION
The app won't run because of this error
/C:/flutter/.pub-cache/hosted/pub.dartlang.org/flutter_overlay_loader-1.0.8/lib/flutter_overlay_loader.dart:102:33: Error: Method 'addPostFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null.
 - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/flutter/packages/flutter/lib/src/widgets/binding.dart').
Try calling using ?. instead.
        WidgetsBinding.instance.addPostFrameCallback((_) {
                                ^^^^^^^^^^^^^^^^^^^^
I added the (?) and everything worked like it should